### PR TITLE
Add recursive type example

### DIFF
--- a/src/conversion_test.ml
+++ b/src/conversion_test.ml
@@ -16,3 +16,32 @@ let () =
     "desired": "F", 
     "temperature": { "u" : "C", "v": 0 }
   }|}
+
+
+(** This is an example how to create a Tree in OCaml 
+    and serialize it in JSON *)
+
+let make_node ?(left = Empty) ?(right = Empty) value= Node {
+  value; 
+  left = Some left; 
+  right = Some right;
+}
+
+let () = 
+  let tree = 
+    make_node 
+      ~left:(make_node 
+        ~left:(make_node "2") 
+        ~right:(make_node "3") 
+        "4"
+      )
+      ~right:(make_node 
+        ~left:(make_node "5")
+        ~right:(make_node "6") 
+        "7"
+      )
+      "8"
+  in 
+  let encoder = Pbrt_bsjson.Encoder.empty() in
+  Conversion.MessageEncoder.encode_binary_tree tree encoder;
+  Pbrt_bsjson.Encoder.to_string encoder |> print_endline 

--- a/src/conversion_test.ml
+++ b/src/conversion_test.ml
@@ -45,3 +45,28 @@ let () =
   let encoder = Pbrt_bsjson.Encoder.empty() in
   Conversion.MessageEncoder.encode_binary_tree tree encoder;
   Pbrt_bsjson.Encoder.to_string encoder |> print_endline 
+
+let make_node_compact ?left  ?right value = ({
+  value; 
+  left;
+  right;
+}:binary_tree_compact)
+
+let () = 
+  let tree = 
+    make_node_compact 
+      ~left:(make_node_compact 
+        ~left:(make_node_compact "2") 
+        ~right:(make_node_compact "3") 
+        "4"
+      )
+      ~right:(make_node_compact 
+        ~left:(make_node_compact "5")
+        ~right:(make_node_compact "6") 
+        "7"
+      )
+      "8"
+  in 
+  let encoder = Pbrt_bsjson.Encoder.empty() in
+  Conversion.MessageEncoder.encode_binary_tree_compact tree encoder;
+  Pbrt_bsjson.Encoder.to_string encoder |> print_endline 

--- a/src/messages.proto
+++ b/src/messages.proto
@@ -41,3 +41,11 @@ message BinaryTree {
     Empty empty = 2;
   }
 }
+
+// This a more compact representation than the previous one and 
+// eventually generates a much smaller JSON 
+message BinaryTreeCompact{
+  string value = 1; 
+  BinaryTreeCompact left = 2; 
+  BinaryTreeCompact right = 3; 
+}

--- a/src/messages.proto
+++ b/src/messages.proto
@@ -21,3 +21,23 @@ message Response {
     Temperature temperature = 2;
   }
 }
+
+
+// Example of a Recursive data structure and how 
+// ocaml-protoc will avoid generating an OCaml 
+// for the Empty message 
+message BinaryTree {
+
+  message Node {
+    string value = 1; 
+    BinaryTree left = 2; 
+    BinaryTree right = 3; 
+  }
+
+  message Empty { }
+
+  oneof t {
+    Node node = 1; 
+    Empty empty = 2;
+  }
+}

--- a/src/messages_pb.ml
+++ b/src/messages_pb.ml
@@ -28,6 +28,22 @@ type response =
   | Error of string
   | Temperature of temperature
 
+type binary_tree_node = {
+  value : string;
+  left : binary_tree option;
+  right : binary_tree option;
+}
+
+and binary_tree_node_mutable = {
+  mutable value : string;
+  mutable left : binary_tree option;
+  mutable right : binary_tree option;
+}
+
+and binary_tree =
+  | Node of binary_tree_node
+  | Empty
+
 let rec default_temperature_unit () = (C:temperature_unit)
 
 let rec default_temperature 
@@ -57,6 +73,24 @@ and default_request_mutable () : request_mutable = {
 }
 
 let rec default_response () : response = Error ("")
+
+let rec default_binary_tree_node 
+  ?value:((value:string) = "")
+  ?left:((left:binary_tree option) = None)
+  ?right:((right:binary_tree option) = None)
+  () : binary_tree_node  = {
+  value;
+  left;
+  right;
+}
+
+and default_binary_tree_node_mutable () : binary_tree_node_mutable = {
+  value = "";
+  left = None;
+  right = None;
+}
+
+and default_binary_tree () : binary_tree = Node (default_binary_tree_node ())
 
 module Make_decoder(Decoder:Pbrt_json.Decoder_sig) = struct
   
@@ -121,6 +155,45 @@ module Make_decoder(Decoder:Pbrt_json.Decoder_sig) = struct
     in
     loop ()
   
+  let rec decode_binary_tree_node d =
+    let v = default_binary_tree_node_mutable () in
+    let continue = ref true in
+    while !continue do
+      match Decoder.key d with
+      | None -> continue := false 
+      | Some ("value", json_value) -> 
+        v.value <- Helper.string json_value "binary_tree_node" "value"
+      | Some ("left", Decoder.Object o) -> 
+        v.left <- Some ((decode_binary_tree o))
+      | Some ("left", _) -> 
+        v.left <- Some ((Pbrt_json.E.unexpected_json_type "binary_tree_node" "left"))
+      | Some ("right", Decoder.Object o) -> 
+        v.right <- Some ((decode_binary_tree o))
+      | Some ("right", _) -> 
+        v.right <- Some ((Pbrt_json.E.unexpected_json_type "binary_tree_node" "right"))
+      
+      | Some (_, _) -> () (*Unknown fields are ignored*)
+    done;
+    ({
+      value = v.value;
+      left = v.left;
+      right = v.right;
+    } : binary_tree_node)
+  
+  and decode_binary_tree d =
+    let rec loop () =
+      match Decoder.key d with
+      | None -> Pbrt_json.E.malformed_variant "binary_tree"
+      | Some ("node", Decoder.Object o) -> 
+        Node ((decode_binary_tree_node o))
+      | Some ("node", _) -> 
+        Node ((Pbrt_json.E.unexpected_json_type "binary_tree" "Node"))
+      | Some ("empty", _) -> Empty
+      
+      | Some (_, _) -> loop ()
+    in
+    loop ()
+  
 end
 
 module Make_encoder(Encoder:Pbrt_json.Encoder_sig) = struct
@@ -158,6 +231,40 @@ module Make_encoder(Encoder:Pbrt_json.Encoder_sig) = struct
         encode_temperature v encoder';
         Encoder.set_object encoder "temperature" encoder';
       end;
+    end
+  
+  let rec encode_binary_tree_node (v:binary_tree_node) encoder = 
+    Encoder.set_string encoder "value" v.value;
+    begin match v.left with
+      | None -> ()
+      | Some v ->
+      begin (* left field *)
+        let encoder' = Encoder.empty () in
+        encode_binary_tree v encoder';
+        Encoder.set_object encoder "left" encoder';
+      end;
+    end;
+    begin match v.right with
+      | None -> ()
+      | Some v ->
+      begin (* right field *)
+        let encoder' = Encoder.empty () in
+        encode_binary_tree v encoder';
+        Encoder.set_object encoder "right" encoder';
+      end;
+    end;
+    ()
+  
+  and encode_binary_tree (v:binary_tree) encoder = 
+    begin match v with
+      | Node v ->
+      begin (* node field *)
+        let encoder' = Encoder.empty () in
+        encode_binary_tree_node v encoder';
+        Encoder.set_object encoder "node" encoder';
+      end;
+      | Empty ->
+      Encoder.set_null encoder "empty"
     end
   
 end

--- a/src/messages_pb.mli
+++ b/src/messages_pb.mli
@@ -21,6 +21,16 @@ type response =
   | Error of string
   | Temperature of temperature
 
+type binary_tree_node = {
+  value : string;
+  left : binary_tree option;
+  right : binary_tree option;
+}
+
+and binary_tree =
+  | Node of binary_tree_node
+  | Empty
+
 
 (** {2 Default values} *)
 
@@ -44,6 +54,17 @@ val default_request :
 val default_response : unit -> response
 (** [default_response ()] is the default value for type [response] *)
 
+val default_binary_tree_node : 
+  ?value:string ->
+  ?left:binary_tree option ->
+  ?right:binary_tree option ->
+  unit ->
+  binary_tree_node
+(** [default_binary_tree_node ()] is the default value for type [binary_tree_node] *)
+
+val default_binary_tree : unit -> binary_tree
+(** [default_binary_tree ()] is the default value for type [binary_tree] *)
+
 module Make_decoder(Decoder:Pbrt_json.Decoder_sig) : sig
   
   (** {2 JSON Decoding} *)
@@ -59,6 +80,12 @@ module Make_decoder(Decoder:Pbrt_json.Decoder_sig) : sig
   
   val decode_response : Decoder.t -> response
   (** [decode_response decoder] decodes a [response] value from [decoder] *)
+  
+  val decode_binary_tree_node : Decoder.t -> binary_tree_node
+  (** [decode_binary_tree_node decoder] decodes a [binary_tree_node] value from [decoder] *)
+  
+  val decode_binary_tree : Decoder.t -> binary_tree
+  (** [decode_binary_tree decoder] decodes a [binary_tree] value from [decoder] *)
   
 end
 module Make_encoder(Encoder:Pbrt_json.Encoder_sig) : sig
@@ -76,5 +103,11 @@ module Make_encoder(Encoder:Pbrt_json.Encoder_sig) : sig
   
   val encode_response : response -> Encoder.t -> unit
   (** [encode_response v encoder] encodes [v] with the given [encoder] *)
+  
+  val encode_binary_tree_node : binary_tree_node -> Encoder.t -> unit
+  (** [encode_binary_tree_node v encoder] encodes [v] with the given [encoder] *)
+  
+  val encode_binary_tree : binary_tree -> Encoder.t -> unit
+  (** [encode_binary_tree v encoder] encodes [v] with the given [encoder] *)
   
 end

--- a/src/messages_pb.mli
+++ b/src/messages_pb.mli
@@ -31,6 +31,12 @@ and binary_tree =
   | Node of binary_tree_node
   | Empty
 
+type binary_tree_compact = {
+  value : string;
+  left : binary_tree_compact option;
+  right : binary_tree_compact option;
+}
+
 
 (** {2 Default values} *)
 
@@ -65,6 +71,14 @@ val default_binary_tree_node :
 val default_binary_tree : unit -> binary_tree
 (** [default_binary_tree ()] is the default value for type [binary_tree] *)
 
+val default_binary_tree_compact : 
+  ?value:string ->
+  ?left:binary_tree_compact option ->
+  ?right:binary_tree_compact option ->
+  unit ->
+  binary_tree_compact
+(** [default_binary_tree_compact ()] is the default value for type [binary_tree_compact] *)
+
 module Make_decoder(Decoder:Pbrt_json.Decoder_sig) : sig
   
   (** {2 JSON Decoding} *)
@@ -86,6 +100,9 @@ module Make_decoder(Decoder:Pbrt_json.Decoder_sig) : sig
   
   val decode_binary_tree : Decoder.t -> binary_tree
   (** [decode_binary_tree decoder] decodes a [binary_tree] value from [decoder] *)
+  
+  val decode_binary_tree_compact : Decoder.t -> binary_tree_compact
+  (** [decode_binary_tree_compact decoder] decodes a [binary_tree_compact] value from [decoder] *)
   
 end
 module Make_encoder(Encoder:Pbrt_json.Encoder_sig) : sig
@@ -109,5 +126,8 @@ module Make_encoder(Encoder:Pbrt_json.Encoder_sig) : sig
   
   val encode_binary_tree : binary_tree -> Encoder.t -> unit
   (** [encode_binary_tree v encoder] encodes [v] with the given [encoder] *)
+  
+  val encode_binary_tree_compact : binary_tree_compact -> Encoder.t -> unit
+  (** [encode_binary_tree_compact v encoder] encodes [v] with the given [encoder] *)
   
 end


### PR DESCRIPTION
Example of how to define and use Recursive type in Protobuf

The JSON genrated is the following (for the compact version)
```JSON
{
  "value":"8",
  "left":{
    "value":"4",
    "left":{
      "value":"2"
    },
    "right":{
      "value":"3"
    }
  },
  "right":{
    "value":"7",
    "left":{
      "value":"5"
    },
    "right":{
      "value":"6"
    }
  }
}
```